### PR TITLE
fix: 通过内存检测工具运行程序时，会崩溃。

### DIFF
--- a/OCAuxiliaryTools.pro
+++ b/OCAuxiliaryTools.pro
@@ -65,7 +65,8 @@ SOURCES += \
     src/utils/pugixml.cpp \
     src/widgets/recentfiles.cpp \
     src/widgets/syncocdialog.cpp \
-    src/widgets/tooltip.cpp
+    src/widgets/tooltip.cpp \
+    src/utils/fileoperation.cpp
 
 HEADERS += \
     src/widgets/BalloonTip.h \
@@ -94,7 +95,8 @@ HEADERS += \
     src/utils/pugixml.hpp \
     src/widgets/recentfiles.h \
     src/widgets/syncocdialog.h \
-    src/widgets/tooltip.h
+    src/widgets/tooltip.h \
+    src/utils/fileoperation.h
 
 FORMS += \
     src/widgets/aboutdialog.ui \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "Method.h"
 #include "mainwindow.h"
 #include "myapp.h"
+#include "fileoperation.h"
 
 void loadLocal();
 extern QVector<QString> filelist;
@@ -30,8 +31,8 @@ int main(int argc, char *argv[]) {
   QDir dir;
   dir.mkpath(QDir::homePath() + "/.ocat/");
   QString strAppExePath = qApp->applicationDirPath();
-  mw_one->copyDirectoryFiles(strAppExePath + "/Database/",
-                             QDir::homePath() + "/.ocat/Database/", false);
+  FileOperation::copyDirectoryFiles(strAppExePath + "/Database/",
+                                      QDir::homePath() + "/.ocat/Database/", false);
 
   QString strDrivers0 = strAppExePath + "/Database/EFI/OC/Drivers/";
   QString strTools0 = strAppExePath + "/Database/EFI/OC/Tools/";
@@ -61,24 +62,24 @@ int main(int argc, char *argv[]) {
   listTools = Method::DirToFileList(strTools0, "*.efi");
 
   for (int i = 0; i < listDrivers.count(); i++) {
-    mw_one->copyFileToPath(strDrivers0 + listDrivers.at(i),
-                           strDrivers1 + listDrivers.at(i), false);
-    mw_one->copyFileToPath(strDrivers0 + listDrivers.at(i),
-                           strDrivers2 + listDrivers.at(i), false);
-    mw_one->copyFileToPath(strDrivers0 + listDrivers.at(i),
-                           strDrivers3 + listDrivers.at(i), false);
-    mw_one->copyFileToPath(strDrivers0 + listDrivers.at(i),
-                           strDrivers4 + listDrivers.at(i), false);
+      FileOperation::copyFileToPath(strDrivers0 + listDrivers.at(i),
+                                    strDrivers1 + listDrivers.at(i), false);
+      FileOperation::copyFileToPath(strDrivers0 + listDrivers.at(i),
+                                    strDrivers2 + listDrivers.at(i), false);
+      FileOperation::copyFileToPath(strDrivers0 + listDrivers.at(i),
+                                    strDrivers3 + listDrivers.at(i), false);
+      FileOperation::copyFileToPath(strDrivers0 + listDrivers.at(i),
+                                    strDrivers4 + listDrivers.at(i), false);
   }
   for (int i = 0; i < listTools.count(); i++) {
-    mw_one->copyFileToPath(strTools0 + listTools.at(i),
-                           strTools1 + listTools.at(i), false);
-    mw_one->copyFileToPath(strTools0 + listTools.at(i),
-                           strTools2 + listTools.at(i), false);
-    mw_one->copyFileToPath(strTools0 + listTools.at(i),
-                           strTools3 + listTools.at(i), false);
-    mw_one->copyFileToPath(strTools0 + listTools.at(i),
-                           strTools4 + listTools.at(i), false);
+      FileOperation::copyFileToPath(strTools0 + listTools.at(i),
+                                    strTools1 + listTools.at(i), false);
+      FileOperation::copyFileToPath(strTools0 + listTools.at(i),
+                                    strTools2 + listTools.at(i), false);
+      FileOperation::copyFileToPath(strTools0 + listTools.at(i),
+                                    strTools3 + listTools.at(i), false);
+      FileOperation::copyFileToPath(strTools0 + listTools.at(i),
+                                    strTools4 + listTools.at(i), false);
   }
 
   // ACPI Files

--- a/src/utils/fileoperation.cpp
+++ b/src/utils/fileoperation.cpp
@@ -1,0 +1,59 @@
+#include "fileoperation.h"
+
+#include <QDir>
+#include <QDebug>
+
+bool FileOperation::copyDirectoryFiles(const QString &fromDir, const QString &toDir, bool coverFileIfExist)
+{
+    QDir sourceDir(fromDir);
+    QDir targetDir(toDir);
+    if (!targetDir.exists()) { /**< 如果目标目录不存在，则进行创建 */
+        if (!targetDir.mkdir(targetDir.absolutePath())) {
+            qWarning() << "Error: Create target Dir failed!";
+            return false;
+        }
+    }
+
+    QFileInfoList fileInfoList = sourceDir.entryInfoList(QDir::NoDotAndDotDot);
+    foreach (QFileInfo fileInfo, fileInfoList) {
+        if (fileInfo.isDir()) { /**< 当为目录时，递归的进行copy */
+            if (!copyDirectoryFiles(fileInfo.filePath(),
+                                    targetDir.filePath(fileInfo.fileName()),
+                                    coverFileIfExist))
+                return false;
+        } else { /**< 当允许覆盖操作时，将旧文件进行删除操作 */
+            if (coverFileIfExist && targetDir.exists(fileInfo.fileName())) {
+                targetDir.remove(fileInfo.fileName());
+            }
+
+            /// 进行文件copy
+            if (!QFile::copy(fileInfo.filePath(),
+                             targetDir.filePath(fileInfo.fileName()))) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool FileOperation::copyFileToPath(QString sourceFile, QString toFile, bool coverFileIfExist)
+{
+    toFile.replace("\\", "/");
+    if (sourceFile == toFile) {
+        return true;
+    }
+    if (!QFile::exists(sourceFile)) {
+        return false;
+    }
+
+    bool exist = QFile::exists(toFile);
+    if (exist) {
+        if (coverFileIfExist)
+            QFile::remove(toFile);
+    }
+
+    if (!QFile::copy(sourceFile, toFile)) {
+        return false;
+    }
+    return true;
+}

--- a/src/utils/fileoperation.h
+++ b/src/utils/fileoperation.h
@@ -1,0 +1,33 @@
+#ifndef FILEOPERATION_H
+#define FILEOPERATION_H
+
+#include <QObject>
+
+class FileOperation : public QObject
+{
+    Q_OBJECT
+public:
+    /**
+     * @brief copyDirectoryFiles 拷贝文件夹
+     * @param fromDir 源文件夹
+     * @param toDir 目的文件夹
+     * @param coverFileIfExist 是否覆盖已存在文件
+     * @return 拷贝成功与否
+     */
+    static bool copyDirectoryFiles(const QString& fromDir,
+                                   const QString& toDir,
+                                   bool coverFileIfExist);
+    /**
+     * @brief copyFileToPath 拷贝文件
+     * @param sourceDir 源文件
+     * @param toDir 目的文件
+     * @param coverFileIfExist 是否覆盖已存在文件
+     * @return 拷贝成功与否
+     */
+    static bool copyFileToPath(QString sourceFile,
+                               QString toFile,
+                               bool coverFileIfExist);
+
+};
+
+#endif // FILEOPERATION_H


### PR DESCRIPTION
main函数中，拷贝文件及文件夹时，mw_one对象没有创建，通过内存检测工具运行程序时，会断言。
将文件拷贝操作封装的文件操作类中，以解决改问题。
对于其它调用文管拷贝操作接口的地方，会在后续代码中修改