### PR TITLE
fix: remove redundant functions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,14 +94,14 @@ int main(int argc, char *argv[]) {
   dir.mkpath(strACPI4);
   listACPI = Method::DirToFileList(strACPI0, "*.aml");
   for (int i = 0; i < listACPI.count(); i++) {
-    mw_one->copyFileToPath(strACPI0 + listACPI.at(i), strACPI1 + listACPI.at(i),
-                           false);
-    mw_one->copyFileToPath(strACPI0 + listACPI.at(i), strACPI2 + listACPI.at(i),
-                           false);
-    mw_one->copyFileToPath(strACPI0 + listACPI.at(i), strACPI3 + listACPI.at(i),
-                           false);
-    mw_one->copyFileToPath(strACPI0 + listACPI.at(i), strACPI4 + listACPI.at(i),
-                           false);
+      FileOperation::copyFileToPath(strACPI0 + listACPI.at(i), strACPI1 + listACPI.at(i),
+                                    false);
+      FileOperation::copyFileToPath(strACPI0 + listACPI.at(i), strACPI2 + listACPI.at(i),
+                                    false);
+      FileOperation::copyFileToPath(strACPI0 + listACPI.at(i), strACPI3 + listACPI.at(i),
+                                    false);
+      FileOperation::copyFileToPath(strACPI0 + listACPI.at(i), strACPI4 + listACPI.at(i),
+                                    false);
   }
 
   QString fileSample =

--- a/src/utils/Method.cpp
+++ b/src/utils/Method.cpp
@@ -8,6 +8,7 @@
 #include "plistserializer.h"
 #include "ui_dlgdatabase.h"
 #include "ui_mainwindow.h"
+#include "fileoperation.h"
 
 extern MainWindow* mw_one;
 extern QString SaveFileName, strIniFile, strAppName, strAppExePath;
@@ -512,20 +513,20 @@ void Method::updateOpenCore() {
     mw_one->copyDirectoryFiles(strSacpi, strTacpi, true);
 
     // Doc
-    Results.append(mw_one->copyFileToPath(
+    Results.append(FileOperation::copyFileToPath(
         tempDir + "Docs/Configuration.pdf",
         mw_one->userDataBaseDir + "doc/Configuration.pdf", true));
-    Results.append(mw_one->copyFileToPath(
+    Results.append(FileOperation::copyFileToPath(
         tempDir + "Docs/Differences.pdf",
         mw_one->userDataBaseDir + "doc/Differences.pdf", true));
 
     // Sample-plist
-    Results.append(mw_one->copyFileToPath(
+    Results.append(FileOperation::copyFileToPath(
         tempDir + "Docs/Sample.plist",
         mw_one->userDataBaseDir + "BaseConfigs/Sample.plist", true));
     QString sa = tempDir + "Docs/SampleCustom.plist";
     if (!QFile(sa).exists()) sa = tempDir + "Docs/SampleFull.plist";
-    Results.append(mw_one->copyFileToPath(
+    Results.append(FileOperation::copyFileToPath(
         sa, mw_one->userDataBaseDir + "BaseConfigs/SampleCustom.plist", true));
 
     // OC Validate
@@ -536,7 +537,7 @@ void Method::updateOpenCore() {
                                   "affect the use of the APP under Mac.") +
                                    "\n\nocvalidate\nmacserial\nocpasswordgen");
     }
-    mw_one->copyFileToPath(tempDir + "Utilities/ocvalidate/ocvalidate",
+    FileOperation::copyFileToPath(tempDir + "Utilities/ocvalidate/ocvalidate",
                            mw_one->userDataBaseDir + "mac/ocvalidate", true);
 
     if (!QFile(tempDir + "Utilities/ocvalidate/ocvalidate.exe").exists()) {
@@ -547,7 +548,7 @@ void Method::updateOpenCore() {
              "affect the use of the APP under Windows.") +
               "\n\nocvalidate.exe\nmacserial.exe\nocpasswordgen.exe");
     }
-    mw_one->copyFileToPath(tempDir + "Utilities/ocvalidate/ocvalidate.exe",
+    FileOperation::copyFileToPath(tempDir + "Utilities/ocvalidate/ocvalidate.exe",
                            mw_one->userDataBaseDir + "win/ocvalidate.exe",
                            true);
 
@@ -560,25 +561,25 @@ void Method::updateOpenCore() {
               "\n\nocvalidate.linux\nmacserial.linux\nocpasswordgen.linux");
     }
 
-    mw_one->copyFileToPath(tempDir + "Utilities/ocvalidate/ocvalidate.linux",
+    FileOperation::copyFileToPath(tempDir + "Utilities/ocvalidate/ocvalidate.linux",
                            mw_one->userDataBaseDir + "linux/ocvalidate", true);
 
     // Mac Serial
-    mw_one->copyFileToPath(tempDir + "Utilities/macserial/macserial",
+    FileOperation::copyFileToPath(tempDir + "Utilities/macserial/macserial",
                            mw_one->userDataBaseDir + "mac/macserial", true);
-    mw_one->copyFileToPath(tempDir + "Utilities/macserial/macserial.exe",
+    FileOperation::copyFileToPath(tempDir + "Utilities/macserial/macserial.exe",
                            mw_one->userDataBaseDir + "win/macserial.exe", true);
 
-    mw_one->copyFileToPath(tempDir + "Utilities/macserial/macserial.linux",
+    FileOperation::copyFileToPath(tempDir + "Utilities/macserial/macserial.linux",
                            mw_one->userDataBaseDir + "linux/macserial", true);
 
     // OC Password Gen
-    mw_one->copyFileToPath(tempDir + "Utilities/ocpasswordgen/ocpasswordgen",
+    FileOperation::copyFileToPath(tempDir + "Utilities/ocpasswordgen/ocpasswordgen",
                            mw_one->userDataBaseDir + "mac/ocpasswordgen", true);
-    mw_one->copyFileToPath(
+    FileOperation::copyFileToPath(
         tempDir + "Utilities/ocpasswordgen/ocpasswordgen.exe",
         mw_one->userDataBaseDir + "win/ocpasswordgen.exe", true);
-    mw_one->copyFileToPath(
+    FileOperation::copyFileToPath(
         tempDir + "Utilities/ocpasswordgen/ocpasswordgen.linux",
         mw_one->userDataBaseDir + "linux/ocpasswordgen", true);
 

--- a/src/widgets/mainwindow.cpp
+++ b/src/widgets/mainwindow.cpp
@@ -6046,28 +6046,6 @@ bool MainWindow::DeleteDirectory(const QString& path) {
   return dir.rmpath(dir.absolutePath());
 }
 
-//拷贝文件：
-bool MainWindow::copyFileToPath(QString sourceDir, QString toDir,
-                                bool coverFileIfExist) {
-  toDir.replace("\\", "/");
-  if (sourceDir == toDir) {
-    return true;
-  }
-  if (!QFile::exists(sourceDir)) {
-    return false;
-  }
-  bool exist = QFile::exists(toDir);
-  if (exist) {
-      if (coverFileIfExist)
-          QFile::remove(toDir);
-  }
-
-  if (!QFile::copy(sourceDir, toDir)) {
-    return false;
-  }
-  return true;
-}
-
 //拷贝文件夹：
 bool MainWindow::copyDirectoryFiles(const QString& fromDir,
                                     const QString& toDir,

--- a/src/widgets/mainwindow.h
+++ b/src/widgets/mainwindow.h
@@ -317,8 +317,6 @@ class MainWindow : public QMainWindow {
   bool copyDirectoryFiles(const QString& fromDir, const QString& toDir,
                           bool coverFileIfExist);
 
-  bool copyFileToPath(QString sourceDir, QString toDir, bool coverFileIfExist);
-
   QString getWMIC(const QString& cmd);
   QString getCpuName();
   QString getCpuId();

--- a/src/widgets/syncocdialog.cpp
+++ b/src/widgets/syncocdialog.cpp
@@ -4,6 +4,7 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 #include "ui_syncocdialog.h"
+#include "fileoperation.h"
 
 extern MainWindow* mw_one;
 extern QString ocVer, ocVerDev, ocFrom, ocFromDev, strIniFile, strAppName,
@@ -815,7 +816,7 @@ void SyncOCDialog::on_btnImport_clicked() {
     dir.mkpath(path);
     QFileInfo fi(FileName);
     QString tar = path + fi.fileName();
-    mw_one->copyFileToPath(FileName, tar, true);
+    FileOperation::copyFileToPath(FileName, tar, true);
     isCheckOC = true;
     mymethod->unZip(fi.fileName());
     isCheckOC = false;


### PR DESCRIPTION
MainWindow::copyFileToPath function replace by FileOperation::copyFileToPath. 
将老的MainWindow::copyFileToPath函数替换成新的FileOperation::copyFIleToPath.