### PR TITLE
fix: the label width to big between qt5.9.9 and qt5.15.0

### DIFF
--- a/src/widgets/mainwindow.cpp
+++ b/src/widgets/mainwindow.cpp
@@ -6001,14 +6001,10 @@ int MainWindow::getTextWidth(QString str, QWidget* w) {
   QFontMetrics fm(myFont);
   int mw;
 
-#if (QT_VERSION <= QT_VERSION_CHECK(5, 9, 9))
+#if (QT_VERSION < QT_VERSION_CHECK(5, 11, 0))
   mw = fm.width(str);
-
-#endif
-
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+#else
   mw = fm.horizontalAdvance(str);
-
 #endif
 
   return mw;


### PR DESCRIPTION
1. not init the mw, so it too big.
2. in Qt 5.11, Use QFontMetrics::horizontalAdvance instead QFontMetrics::width.